### PR TITLE
Fix "QgsProcessingParameterNumber(): arguments did not match any overloaded call" error

### DIFF
--- a/processing_provider/Vect_DirectionalMerge.py
+++ b/processing_provider/Vect_DirectionalMerge.py
@@ -122,7 +122,7 @@ class DirectionalMerge(QgsProcessingAlgorithm):
             QgsProcessingParameterNumber(
                 self.ANGLE,
                 self.tr('Tolerance in degrees', 'Ngưỡng (độ)'),
-                type =1,
+                type = QgsProcessingParameterNumber.Double,
                 defaultValue = 30
                 )
             )


### PR DESCRIPTION
Fixes #3
Fixes #5